### PR TITLE
Add environment variable to GitHub workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Build with maven
         run: mvn -B package --file backend/pom.xml
+        env:
+          BETTERSTACK_TOKEN_BACKEND_TESTS: ${{ secrets.BETTERSTACK_TOKEN_BACKEND_TESTS}}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The GitHub Deploy workflow has been enhanced by adding the 'BETTERSTACK_TOKEN_BACKEND_TESTS' as an environment variable. This change has been made to the 'Build with maven' step which will now use the secret token during the build process.