### PR TITLE
Enhance error handling in LoggingInterceptor

### DIFF
--- a/backend/src/main/java/com/aljoschazoeller/backend/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/com/aljoschazoeller/backend/logging/LoggingInterceptor.java
@@ -6,30 +6,51 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.util.Optional;
+
 public class LoggingInterceptor implements HandlerInterceptor {
 
     private final UserService userService;
+    private static final String APP_USER_ID = "appUserId";
 
     public LoggingInterceptor(UserService userService) {
         this.userService = userService;
     }
 
+    private Optional<Integer> getAuthenticatedGithubId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (
+                authentication != null &&
+                authentication.getPrincipal() instanceof OAuth2User oAuth2User &&
+                oAuth2User.getAttribute("id") instanceof Integer githubId
+        ) {
+            return Optional.of(githubId);
+        }
+
+        return Optional.empty();
+    }
+
     @Override
     public boolean preHandle(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
-        OAuth2User principal = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        Integer githubId = principal.getAttribute("id");
-        assert githubId != null;
-        AppUser appUser = userService.findByGithubId(githubId.toString());
-        MDC.put("appUserId", appUser.id());
+        getAuthenticatedGithubId().ifPresentOrElse(
+                githubId -> {
+                    AppUser appUser = userService.findByGithubId(githubId.toString());
+                    MDC.put(APP_USER_ID, appUser.id());
+                },
+                () -> MDC.put(APP_USER_ID, "N/A")
+        );
+
         return true;
     }
 
     @Override
-    public void afterCompletion(@NonNull  HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception exception) {
-        MDC.remove("appUserId");
+    public void afterCompletion(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception exception) {
+        MDC.remove(APP_USER_ID);
     }
 }


### PR DESCRIPTION
Added a private method getAuthenticatedGithubId to check for authenticated Github User ID. This approach ensures that potential null pointers are properly handled. If no authenticated Github User ID is found, "N/A" is logged instead of throwing an error.