### PR TITLE
Remove redundant null check in LoggingInterceptor

### DIFF
--- a/backend/src/main/java/com/aljoschazoeller/backend/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/com/aljoschazoeller/backend/logging/LoggingInterceptor.java
@@ -32,7 +32,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
         log.error("PRINCIPAL {}", authentication.getPrincipal());
 
         if (
-                authentication != null &&
                 authentication.getPrincipal() instanceof OAuth2User oAuth2User &&
                 oAuth2User.getAttribute("id") instanceof Integer githubId
         ) {


### PR DESCRIPTION
The null check for the "authentication" variable in LoggingInterceptor was redundant and potentially misleading. This modification improves code clarity as the authentication's' Principal instance will always be checked first before its attributes regardless.